### PR TITLE
Prepare a 1.0.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# rerun_except 1.0.0 (2021-03-01)
+
+* The interface has been stable for over 18 months, so a fully stable release
+  now seems appropriate.
+
+* Improve documentation.
+
+
 # rerun_except 0.1.2 (2020-04-28)
 
 * Silence compiler warning about the non-use of "dyn".

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rerun_except"
 description = "Rerun a cargo build except when specified files are changed"
 repository = "https://github.com/softdevteam/rerun_except/"
-version = "0.1.2"
+version = "1.0.0"
 authors = ["Laurence Tratt <laurie@tratt.net>"]
 readme = "README.md"
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
Since the API has been stable for over 18 months, it seems reasonable to me to assume that it'll be fairly stable going forwards, and that we can make this clear to possible users by making this a 1.0.0 release.